### PR TITLE
Update x/sys to get MAP_CONCEAL on openbsd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/awnumar/memcall
 
 go 1.12
 
-require golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
+require golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24 h1:R8bzl0244nw47n1xKs1MUMAaTNgjavKcN/aX2Ss3+Fo=
+golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/memcall_openbsd.go
+++ b/memcall_openbsd.go
@@ -9,8 +9,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var _MAP_CONCEAL = 0x8000
-
 // Lock is a wrapper for mlock(2).
 func Lock(b []byte) error {
 	// Call mlock.
@@ -33,7 +31,7 @@ func Unlock(b []byte) error {
 // Alloc allocates a byte slice of length n and returns it.
 func Alloc(n int) ([]byte, error) {
 	// Allocate the memory.
-	b, err := unix.Mmap(-1, 0, n, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANON|_MAP_CONCEAL)
+	b, err := unix.Mmap(-1, 0, n, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANON|unix.MAP_CONCEAL)
 	if err != nil {
 		return nil, fmt.Errorf("<memcall> could not allocate [Err: %s]", err)
 	}


### PR DESCRIPTION
With golang/go#34589 fixed, MAP_CONCEAL is now defined for all GOARCHes
on openbsd.

Fixes #1