### PR TITLE
Generation of errors would crash for most functions if called with a z…

### DIFF
--- a/memcall.go
+++ b/memcall.go
@@ -2,6 +2,7 @@ package memcall
 
 import (
 	"runtime"
+	"unsafe"
 )
 
 // MemoryProtectionFlag specifies some particular memory protection flag.
@@ -38,4 +39,19 @@ func wipe(buf []byte) {
 		buf[i] = 0
 	}
 	runtime.KeepAlive(buf)
+}
+
+// Placeholder variable for when we need a valid pointer to zero bytes.
+var _zero uintptr
+
+// Auxiliary functions.
+func _getStartPtr(b []byte) unsafe.Pointer {
+	if len(b) > 0 {
+		return unsafe.Pointer(&b[0])
+	}
+	return unsafe.Pointer(&_zero)
+}
+
+func _getPtr(b []byte) uintptr {
+	return uintptr(_getStartPtr(b))
 }

--- a/memcall_openbsd.go
+++ b/memcall_openbsd.go
@@ -13,7 +13,7 @@ import (
 func Lock(b []byte) error {
 	// Call mlock.
 	if err := unix.Mlock(b); err != nil {
-		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", _getSimplePtr(b), err)
 	}
 
 	return nil
@@ -22,7 +22,7 @@ func Lock(b []byte) error {
 // Unlock is a wrapper for munlock(2).
 func Unlock(b []byte) error {
 	if err := unix.Munlock(b); err != nil {
-		return fmt.Errorf("<memcall> could not free lock on %p [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not free lock on %p [Err: %s]", _getSimplePtr(b), err)
 	}
 
 	return nil
@@ -55,7 +55,7 @@ func Free(b []byte) error {
 
 	// Free the memory back to the kernel.
 	if err := unix.Munmap(b); err != nil {
-		return fmt.Errorf("<memcall> could not deallocate %p [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not deallocate %p [Err: %s]", _getSimplePtr(b), err)
 	}
 
 	return nil
@@ -76,7 +76,7 @@ func Protect(b []byte, mpf MemoryProtectionFlag) error {
 
 	// Change the protection value of the byte slice.
 	if err := unix.Mprotect(b, prot); err != nil {
-		return fmt.Errorf("<memcall> could not set %d on %p [Err: %s]", prot, &b[0], err)
+		return fmt.Errorf("<memcall> could not set %d on %p [Err: %s]", prot, _getSimplePtr(b), err)
 	}
 
 	return nil

--- a/memcall_osx.go
+++ b/memcall_osx.go
@@ -12,7 +12,7 @@ import (
 // Lock is a wrapper for mlock(2).
 func Lock(b []byte) error {
 	if err := unix.Mlock(b); err != nil {
-		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", _getSimplePtr(b), err)
 	}
 
 	return nil
@@ -21,7 +21,7 @@ func Lock(b []byte) error {
 // Unlock is a wrapper for munlock(2).
 func Unlock(b []byte) error {
 	if err := unix.Munlock(b); err != nil {
-		return fmt.Errorf("<memcall> could not free lock on %p [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not free lock on %p [Err: %s]", _getSimplePtr(b), err)
 	}
 
 	return nil
@@ -54,7 +54,7 @@ func Free(b []byte) error {
 
 	// Free the memory back to the kernel.
 	if err := unix.Munmap(b); err != nil {
-		return fmt.Errorf("<memcall> could not deallocate %p [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not deallocate %p [Err: %s]", _getSimplePtr(b), err)
 	}
 
 	return nil
@@ -75,7 +75,7 @@ func Protect(b []byte, mpf MemoryProtectionFlag) error {
 
 	// Change the protection value of the byte slice.
 	if err := unix.Mprotect(b, prot); err != nil {
-		return fmt.Errorf("<memcall> could not set %d on %p [Err: %s]", prot, &b[0], err)
+		return fmt.Errorf("<memcall> could not set %d on %p [Err: %s]", prot, _getSimplePtr(b), err)
 	}
 
 	return nil

--- a/memcall_test.go
+++ b/memcall_test.go
@@ -1,6 +1,10 @@
 package memcall
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestCycle(t *testing.T) {
 	buffer, err := Alloc(32)
@@ -57,5 +61,22 @@ func TestProtFlags(t *testing.T) {
 	}
 	if ReadWrite().flag != 6 {
 		t.Error("ReadWrite value is", ReadWrite().flag)
+	}
+}
+
+func TestGetStartPtr(t *testing.T) {
+	str := fmt.Sprintf("<memcall> could not deallocate %p", _getStartPtr(nil))
+	if !strings.HasPrefix(str, "<memcall> could not deallocate") {
+		t.Error("Formatted start pointer error is", str)
+	}
+
+	str = fmt.Sprintf("<memcall> could not deallocate %p", _getStartPtr([]byte{}))
+	if !strings.HasPrefix(str, "<memcall> could not deallocate") {
+		t.Error("Formatted start pointer error is", str)
+	}
+
+	str = fmt.Sprintf("<memcall> could not deallocate %p", _getStartPtr([]byte{1, 2, 3}))
+	if !strings.HasPrefix(str, "<memcall> could not deallocate") {
+		t.Error("Formatted start pointer error is", str)
 	}
 }

--- a/memcall_unix.go
+++ b/memcall_unix.go
@@ -16,7 +16,7 @@ func Lock(b []byte) error {
 
 	// Call mlock.
 	if err := unix.Mlock(b); err != nil {
-		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", _getStartPtr(b), err)
 	}
 
 	return nil
@@ -25,7 +25,7 @@ func Lock(b []byte) error {
 // Unlock is a wrapper for munlock(2).
 func Unlock(b []byte) error {
 	if err := unix.Munlock(b); err != nil {
-		return fmt.Errorf("<memcall> could not free lock on %p [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not free lock on %p [Err: %s]", _getStartPtr(b), err)
 	}
 
 	return nil
@@ -58,7 +58,7 @@ func Free(b []byte) error {
 
 	// Free the memory back to the kernel.
 	if err := unix.Munmap(b); err != nil {
-		return fmt.Errorf("<memcall> could not deallocate %p [Err: %s]", &b[0], err)
+		return fmt.Errorf("<memcall> could not deallocate %p [Err: %s]", _getStartPtr(b), err)
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func Protect(b []byte, mpf MemoryProtectionFlag) error {
 
 	// Change the protection value of the byte slice.
 	if err := unix.Mprotect(b, prot); err != nil {
-		return fmt.Errorf("<memcall> could not set %d on %p [Err: %s]", prot, &b[0], err)
+		return fmt.Errorf("<memcall> could not set %d on %p [Err: %s]", prot, _getStartPtr(b), err)
 	}
 
 	return nil


### PR DESCRIPTION
…ero-length slice. This commit makes sure we will always get a valid pointer for the error output.