### PR TITLE
Fix no support for MADV_DONTDUMP on solaris/illumos

### DIFF
--- a/memcall_solaris.go
+++ b/memcall_solaris.go
@@ -1,5 +1,4 @@
-//go:build !windows && !darwin && !openbsd && !freebsd && !aix && !netbsd && !solaris
-
+//go:build solaris
 package memcall
 
 import (
@@ -11,9 +10,6 @@ import (
 
 // Lock is a wrapper for mlock(2), with extra precautions.
 func Lock(b []byte) error {
-	// Advise the kernel not to dump. Ignore failure.
-	unix.Madvise(b, unix.MADV_DONTDUMP)
-
 	// Call mlock.
 	if err := unix.Mlock(b); err != nil {
 		return fmt.Errorf("<memcall> could not acquire lock on %p, limit reached? [Err: %s]", _getStartPtr(b), err)


### PR DESCRIPTION
Thank you in advance for considering this change. I ran into a issue which I initially thought was a problem with `golangci-lint`, but later after some debugging I observed that the problem is actually with building targeting Solaris and illumos.

This is what I observed from running specific linter:
```
bash-5.2$ golangci-lint run -E typecheck .
main.go:6:2: could not import github.com/awnumar/memcall (-: # github.com/awnumar/memcall
../../go/pkg/mod/github.com/awnumar/memcall@v0.3.0/memcall_unix.go:15:23: undefined: unix.MADV_DONTDUMP) (typecheck)
	"github.com/awnumar/memcall"
	^
```
The fix is straight-forward, but unfortunately adds duplication.

To test, I created a small project with the following `go.mod` file:
```
module example.com/debug-golangci-lint

go 1.22.4

require github.com/awnumar/memcall v0.3.0

require golang.org/x/sys v0.20.0 // indirect
```

**Before change:**
```
bash-5.2$ go build
# github.com/awnumar/memcall
../../go/pkg/mod/github.com/awnumar/memcall@v0.3.0/memcall_unix.go:15:23: undefined: unix.MADV_DONTDUMP
```
I went ahead and used the replace directive to point to my fork with changes.

**After change:**
```
module example.com/debug-golangci-lint

go 1.22.4

require github.com/awnumar/memcall v0.3.0

require golang.org/x/sys v0.20.0 // indirect

replace github.com/awnumar/memcall => github.com/szaydel/memcall v1.0.1-test
```

At this point building and linting succeed.
```
$ go mod tidy && golangci-lint run -E typecheck . ; echo $?
0
```